### PR TITLE
Update Pet_Default_v5_Dark.theme

### DIFF
--- a/Mods/Pet_Default_v5_Dark.theme
+++ b/Mods/Pet_Default_v5_Dark.theme
@@ -1,8 +1,7 @@
 @description Default v5 Dark Theme
-@version 1.1
+@version 1.0
 @changelog
   - Updated to v5.22 (added preview)
-  - modified midi_note_colormap
 @provides
   Default_5_Dark.ReaperThemeZip http://stash.reaper.fm/1923/Default_5_Dark.ReaperThemeZip
   [data] toolbar_icons/toolbar_midi_mode_named_notes_off_Drums.png http://stash.reaper.fm/28155/toolbar_midi_mode_named_notes_off_Drums.png


### PR DESCRIPTION
Changed Version back to 1.0 and changelog as it was in the original, but shortened the "about" text. Background: I just wanted to change the MIDI-Editor screenshot in the thread and while changing it in the stash, I previewed the thread to check if it is o.k. and noticed that the other screenshots did not work too. Even the screenshots I haven't touched (e.g. "Overview" and "Arrange and TCP"). I don't know how, but suddenly the theme itself was gone too, so I had to make it new in the stash.